### PR TITLE
enable bash and zsh completion automatically

### DIFF
--- a/argo.rb
+++ b/argo.rb
@@ -10,5 +10,17 @@ class Argo < Formula
     def install
         bin.install "argo-darwin-amd64"
         mv bin/"argo-darwin-amd64", bin/"argo"
+
+        # Ensure argo is executable
+        require "fileutils"
+        FileUtils.chmod("+x","#{bin}/argo")
+        
+        # Install bash completion
+        output = Utils.popen_read("#{bin}/argo completion bash")
+        (bash_completion/"argo").write output
+        
+        # Install zsh completion
+        output = Utils.popen_read("#{bin}/argo completion zsh")
+        (zsh_completion/"_argo").write output
     end
 end

--- a/argo.rb
+++ b/argo.rb
@@ -12,7 +12,6 @@ class Argo < Formula
         mv bin/"argo-darwin-amd64", bin/"argo"
 
         # Ensure argo is executable
-        require "fileutils"
         FileUtils.chmod("+x","#{bin}/argo")
         
         # Install bash completion

--- a/argocd.rb
+++ b/argocd.rb
@@ -13,7 +13,6 @@ class Argocd < Formula
         mv bin/"argocd-darwin-amd64", bin/"argocd"
 
         # Ensure argocd is executable
-        require "fileutils"
         FileUtils.chmod("+x","#{bin}/argocd")
 
         # Install bash completion

--- a/argocd.rb
+++ b/argocd.rb
@@ -11,5 +11,17 @@ class Argocd < Formula
     def install
         bin.install "argocd-darwin-amd64"
         mv bin/"argocd-darwin-amd64", bin/"argocd"
+
+        # Ensure argocd is executable
+        require "fileutils"
+        FileUtils.chmod("+x","#{bin}/argocd")
+
+        # Install bash completion
+        output = Utils.popen_read("#{bin}/argocd completion bash")
+        (bash_completion/"argocd").write output
+
+        # Install zsh completion
+        output = Utils.popen_read("#{bin}/argocd completion zsh")
+        (zsh_completion/"_argocd").write output
     end
 end


### PR DESCRIPTION
Bash and Zsh completion have been implemented for Argo (and will be for [Argo CD v2.3.0](#2 )).
I did not even notice that Argo CLI supported bash completion for weeks.  Once I found it, I loved it, and wanted to share that love with others.

This will ensure that command-line completion "just works" for those who want to use it for Argo, and that it will work for Argo CD v2.3.0.

Note that it would be best for this PR to go in after #2  to ensure that people who have manually generated the completion scripts are not disturbed.