### PR TITLE
Add LinuxBrew support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ brew uninstall argocd
 ## Updating a tap
 To update and test formula, run ./update.sh <path/to/binary>. e.g.:
 ```
-docker run -v $PWD:/mnt --rm --entrypoint cp argoproj/argocd:v0.11.0-rc4 /usr/local/bin/argocd-darwin-amd64 /mnt
-./update.sh ./argocd-darwin-amd64
+docker run -v $PWD:/mnt --rm --entrypoint cp argoproj/argocd:v1.1.2 /usr/local/bin/argocd /usr/local/bin/argocd-darwin-amd64 /mnt
+./update.sh ./argocd-darwin-amd64 ./argocd
 ```
 Then verify the tap works by running:
 ```

--- a/argocd.rb
+++ b/argocd.rb
@@ -2,14 +2,24 @@
 class Argocd < Formula
     desc "GitOps Continuous Delivery for Kubernetes"
     homepage "https://argoproj.io"
-    url "https://github.com/argoproj/argo-cd/releases/download/v1.1.2/argocd-darwin-amd64"
-    sha256 "bef39f7d2d99880aacf8ec3f8ae3e5aa00efbe8569e566b116b9400411d1e9ca"
+    baseurl = "https://github.com/argoproj/argo-cd/releases/download"
     version "1.1.2"
 
     bottle :unneeded
 
+    if OS.mac?
+      kernel = "darwin"
+      sha256 "bef39f7d2d99880aacf8ec3f8ae3e5aa00efbe8569e566b116b9400411d1e9ca"
+    elsif OS.linux?
+      kernel = "linux"
+      sha256 "f186759409f7a3fe6ea6633b8d14ead7b16815b84981ba79fc1dd048f77d7f45"
+    end
+
+    @@bin_name = "argocd-" + kernel + "-amd64"
+    url baseurl + "/v1.1.2/" + @@bin_name
+
     def install
-        bin.install "argocd-darwin-amd64"
-        mv bin/"argocd-darwin-amd64", bin/"argocd"
+      bin.install @@bin_name
+      mv bin/ + @@bin_name.to_s, bin/"argocd"
     end
 end

--- a/update.sh
+++ b/update.sh
@@ -1,22 +1,24 @@
 #!/bin/sh
 
-if [ "$#" -ne 1 ]; then
-  echo "Usage: ./update.sh ~/go/src/github.com/argoproj/argo-cd/dist/argocd-darwin-amd64"
+if [ "$#" -lt 2 ]; then
+  echo "Usage: ./update.sh ~/go/src/github.com/argoproj/argo-cd/dist/argocd-darwin-amd64 ~/go/src/github.com/argoproj/argo-cd/dist/argocd-linux-amd64"
   exit 1
 fi
 
-BINPATH=$1
-BINFULLNAME=$(basename ${BINPATH})
-BINSHORTNAME=$(echo ${BINFULLNAME} | cut -d- -f1)
-SHA256=$(shasum -a 256 ${BINPATH} | awk '{print $1}')
+OSX_BINPATH="$1"
+LINUX_BINPATH="$2"
+BINFULLNAME=$(basename "${OSX_BINPATH}")
+BINSHORTNAME=$(echo "${BINFULLNAME}" | cut -d- -f1)
+OSX_SHA256=$(shasum -a 256 "${OSX_BINPATH}" | awk '{print $1}')
+LINUX_SHA256=$(shasum -a 256 "${LINUX_BINPATH}" | awk '{print $1}')
 
 if [ "${BINSHORTNAME}" = "argocd" ]; then
   CLASSNAME="Argocd"
-  VERSION=$(${BINPATH} version --client --short | awk -F'[v+]' '{print $2}')
+  VERSION=$({ ${OSX_BINPATH} version --client --short || ${LINUX_BINPATH} version --client --short; } 2>/dev/null | awk -F'[v+]' '{print $2}')
   DESC="GitOps Continuous Delivery for Kubernetes"
 elif [ "${BINSHORTNAME}" = "argo" ]; then
   CLASSNAME="Argo"
-  VERSION=$(${BINPATH} version --short | awk -F'[v+]' '{print $2}')
+  VERSION=$({ ${OSX_BINPATH} verison --short || ${LINUX_BINPATH} version --short; } 2>/dev/null | awk -F'[v+]' '{print $2}')
   DESC="Get stuff done with container-native workflows for Kubernetes."
 else
   echo "Unsupported binary: ${BINFULLNAME}"
@@ -27,15 +29,25 @@ TEMPLATE="# This is an auto-generated file. DO NOT EDIT
 class ${CLASSNAME} < Formula
     desc \"${DESC}\"
     homepage \"https://argoproj.io\"
-    url \"https://github.com/argoproj/argo-cd/releases/download/v${VERSION}/${BINFULLNAME}\"
-    sha256 \"${SHA256}\"
+    baseurl = \"https://github.com/argoproj/argo-cd/releases/download\"
     version \"${VERSION}\"
 
     bottle :unneeded
 
+    if OS.mac?
+      kernel = \"darwin\"
+      sha256 \"${OSX_SHA256}\"
+    elsif OS.linux?
+      kernel = \"linux\"
+      sha256 \"${LINUX_SHA256}\"
+    end
+
+    @@bin_name = \"${BINSHORTNAME}-\" + kernel + \"-amd64\"
+    url baseurl + \"/v${VERSION}/\" + @@bin_name
+
     def install
-        bin.install \"${BINFULLNAME}\"
-        mv bin/\"${BINFULLNAME}\", bin/\"${BINSHORTNAME}\"
+      bin.install @@bin_name
+      mv bin/ + @@bin_name.to_s, bin/\"${BINSHORTNAME}\"
     end
 end"
 


### PR DESCRIPTION
  - Update README.md to reflect that update.sh needs two arguments now
  - Add Linux checking and sha256 support for the linux binary
  - Variablize download URL and installation according to kernel name