### PR TITLE
Update argo to version 2.4.1

### DIFF
--- a/argo.rb
+++ b/argo.rb
@@ -1,9 +1,9 @@
 class Argo < Formula
     desc "Get stuff done with container-native workflows for Kubernetes."
     homepage "https://argoproj.io"
-    url "https://github.com/argoproj/argo/releases/download/v2.3.0/argo-darwin-amd64"
-    sha256 "f74402daa95168bbb9f6c62117a28b8260da5e2357d71681d9f5b458fb497542"
-    version "2.3.0"
+    url "https://github.com/argoproj/argo/releases/download/v2.4.1/argo-darwin-amd64"
+    sha256 "fceff61499b1c0d0609ba9b7b09506974a544ce1b9c6efaecc1372e425a9cb8e"
+    version "2.4.1"
 
     bottle :unneeded
 
@@ -13,11 +13,11 @@ class Argo < Formula
 
         # Ensure argo is executable
         FileUtils.chmod("+x","#{bin}/argo")
-        
+
         # Install bash completion
         output = Utils.popen_read("#{bin}/argo completion bash")
         (bash_completion/"argo").write output
-        
+
         # Install zsh completion
         output = Utils.popen_read("#{bin}/argo completion zsh")
         (zsh_completion/"_argo").write output


### PR DESCRIPTION
This updates the argo executable from version 2.3.0 to 2.4.1

Tested via:

```shell
>> brew upgrade --build-from-source argo.rb
==> Upgrading 1 outdated package:
argo 2.3.0 -> 2.4.1
==> Upgrading argo
==> Downloading https://github.com/argoproj/argo/releases/download/v2.4.1/argo-darwin-amd64
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/100982449/322f6a80-e9ed-11e9-885d-3b4373dddc1c?X-Amz-Algorithm=AWS4-HM
######################################################################## 100.0%
==> Caveats
Bash completion has been installed to:
  /usr/local/etc/bash_completion.d

zsh completions have been installed to:
  /usr/local/share/zsh/site-functions
==> Summary
🍺  /usr/local/Cellar/argo/2.4.1: 5 files, 39.5MB, built in 29 seconds
Removing: /usr/local/Cellar/argo/2.3.0... (3 files, 33.6MB)
```

and

```shell
>> argo version                                                                                                  ⏎ update_argo_v2.4.1 ⬆✔
argo: v2.4.1
  BuildDate: 2019-10-08T23:15:27Z
  GitCommit: d7f099992d8cf93c280df2ed38a0b9a1b2614e56
  GitTreeState: clean
  GitTag: v2.4.1
  GoVersion: go1.11.5
  Compiler: gc
  Platform: darwin/amd64
```