### PR TITLE
update argocd checksums for v1.3.5

### DIFF
--- a/argocd.rb
+++ b/argocd.rb
@@ -9,10 +9,10 @@ class Argocd < Formula
 
     if OS.mac?
       kernel = "darwin"
-      sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
+      sha256 "dac4db6d3edd1d3b54664bfe46f333f615eafe3741a9c4ffa9e43df7ab7aba47"
     elsif OS.linux?
       kernel = "linux"
-      sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
+      sha256 "94900db8194104f4714665c350ca7e849cb27d224965a994b2f4da1729aa00ba"
     end
 
     @@bin_name = "argocd-" + kernel + "-amd64"


### PR DESCRIPTION
This updates the checksums for `v1.3.5`.  Looks like argo-cd was updated to `v1.3.6` with a script then downgraded to `v1.3.5` by hand and the checksums were overlooked.

brew is currently failing to install argo-cd due to mismatched checksums

```
~ ➤  brew install argoproj/tap/argocd
==> Installing argocd from argoproj/tap
==> Downloading https://github.com/argoproj/argo-cd/releases/download/v1.3.5/argocd-darwin-amd64
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/120896210/bf8f4980-1a86-11ea-89f3-0eb739ffe202?X-Amz-Algorithm=AWS4-HMAC-
######################################################################## 100.0%
Error: An exception occurred within a child process:
  ChecksumMismatchError: SHA256 mismatch
Expected: 0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5
  Actual: dac4db6d3edd1d3b54664bfe46f333f615eafe3741a9c4ffa9e43df7ab7aba47
 Archive: /Users/alex/Library/Caches/Homebrew/downloads/02dc6a52b7d57df4e9f1293b8650c3ce63ac227aa524ab61728644113178c484--argocd-darwin-amd64
To retry an incomplete download, remove the file above.
```
