### PR TITLE
fix checksum for darwin

### DIFF
--- a/argo.rb
+++ b/argo.rb
@@ -9,7 +9,7 @@ class Argo < Formula
 
     if OS.mac?
       kernel = "darwin"
-      sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
+      sha256 "645448115e79b109bb4cff105dbaca2b41522a306ce6d41bc1a893ade5394dc7"
     elsif OS.linux?
       kernel = "linux"
       sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"


### PR DESCRIPTION
Seems strange that darwin and linux have the same checksum.
This PR fix it.