### PR TITLE
chore: remove calling bottle :unneeded

### DIFF
--- a/kubectl-argo-rollouts.rb
+++ b/kubectl-argo-rollouts.rb
@@ -5,8 +5,6 @@ class KubectlArgoRollouts < Formula
     baseurl = "https://github.com/argoproj/argo-rollouts/releases/download"
     version "v1.0.4"
 
-    bottle :unneeded
-
     if OS.mac?
       kernel = "darwin"
       sha256 "98ff3334a7e136fbbb74d7e73064d921baeb94ca1d64fe2d4010837ae6601a8e"


### PR DESCRIPTION
This deprecation was added here, it looks like: [Homebrew/brew@f65d525](https://github.com/Homebrew/brew/commit/f65d525693a45c8e4c2ebc1452080f08c363ee15#diff-f12455e8eb757e3223300c7c544b5b752394173c2a9bb0440443d5673b151fb3)

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the argoproj/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/argoproj/homebrew-tap/kubectl-argo-rollouts.rb:8

brew --version
Homebrew 3.3.0-6-g5889b44
Homebrew/homebrew-core (git revision 359f9f16171; last commit 2021-10-25)
Homebrew/homebrew-cask (git revision 9d41276bdb; last commit 2021-10-26)
```