### PR TITLE
remove deprecated `bottle :unneeded`

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -46,8 +46,6 @@ class ${CLASSNAME} < Formula
     baseurl = \"${URL_BASE}\"
     version \"${VERSION}\"
 
-    bottle :unneeded
-
     if OS.mac?
       kernel = \"darwin\"
       sha256 \"${OSX_SHA256}\"


### PR DESCRIPTION
Right now when `brew update`ing I get this warning.

```
brew update
Updated Homebrew from fecacdce4 to 241dd2ce2.
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the spotify/public tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/spotify/homebrew-public/scio.rb:7
```

homebrew deprecated it [here](https://github.com/Homebrew/brew/pull/11239).
There's no replacement, and I don't think it's needed anymore.