### PR TITLE
chore: upgrade argo rollouts cli to 1.4

### DIFF
--- a/kubectl-argo-rollouts@1.4.rb
+++ b/kubectl-argo-rollouts@1.4.rb
@@ -1,5 +1,5 @@
 # This is an auto-generated file. DO NOT EDIT
-class KubectlArgoRollouts < Formula
+class KubectlArgoRolloutsAT14 < Formula
     desc "Kubectl Argo Rollouts Plugin."
     homepage "https://argoproj.io"
     baseurl = "https://github.com/argoproj/argo-rollouts/releases/download"


### PR DESCRIPTION
Ran

```
./update.sh kubectl-argo-rollouts v1.4.0
./update.sh kubectl-argo-rollouts v1.4.0 @1.4
```

Signed-off-by: zachaller <zachaller@users.noreply.github.com>