### PR TITLE
kubectl-argo-rollouts: Update to 1.7.1

### DIFF
--- a/kubectl-argo-rollouts.rb
+++ b/kubectl-argo-rollouts.rb
@@ -3,18 +3,18 @@ class KubectlArgoRollouts < Formula
     desc "Kubectl Argo Rollouts Plugin."
     homepage "https://argoproj.io"
     baseurl = "https://github.com/argoproj/argo-rollouts/releases/download"
-    version "v1.6.0"
+    version "v1.7.1"
 
     if OS.mac?
       kernel = "darwin"
-      sha256 "915bc4951741e7ac0760448a48590f455ff5cc4a2ae0fd5834ded74080bc4402"
+      sha256 "173f56252e6d08fe564638a0e28360994430e4ca444713bd5ccfe6392d4a02fa"
     elsif OS.linux?
       kernel = "linux"
-      sha256 "690cff6930282d5898ee3b13e2f446b1cf7d3a1eafbb840be9185c599ab22d73"
+      sha256 "b42859a4ead2b02dc1a53a101490f60adc9915b602e033ddc49e78e74a20895b"
     end
 
     @@bin_name = "kubectl-argo-rollouts-" + kernel + "-amd64"
-    url baseurl + "/v1.6.0/" + @@bin_name
+    url baseurl + "/v1.7.1/" + @@bin_name
 
     def install
       bin.install @@bin_name

--- a/kubectl-argo-rollouts@1.7.rb
+++ b/kubectl-argo-rollouts@1.7.rb
@@ -3,18 +3,18 @@ class KubectlArgoRolloutsAT17 < Formula
     desc "Kubectl Argo Rollouts Plugin."
     homepage "https://argoproj.io"
     baseurl = "https://github.com/argoproj/argo-rollouts/releases/download"
-    version "v1.7.0-rc1"
+    version "v1.7.1"
 
     if OS.mac?
       kernel = "darwin"
-      sha256 "637d9fcda4fc8380b908278ed691b7c52b767bb6a966b0869fbc4c38e722be36"
+      sha256 "173f56252e6d08fe564638a0e28360994430e4ca444713bd5ccfe6392d4a02fa"
     elsif OS.linux?
       kernel = "linux"
-      sha256 "0a329c8540b79b01dc58d2533e8a6f2130107ecb97cd04c0eff8527689c60e58"
+      sha256 "b42859a4ead2b02dc1a53a101490f60adc9915b602e033ddc49e78e74a20895b"
     end
 
     @@bin_name = "kubectl-argo-rollouts-" + kernel + "-amd64"
-    url baseurl + "/v1.7.0-rc1/" + @@bin_name
+    url baseurl + "/v1.7.1/" + @@bin_name
 
     def install
       bin.install @@bin_name


### PR DESCRIPTION
This updates the base formula as well as the @1.7 specific one.