### PR TITLE
Update kubectl-argo-rollouts to v1.7.2

### DIFF
--- a/kubectl-argo-rollouts.rb
+++ b/kubectl-argo-rollouts.rb
@@ -3,18 +3,18 @@ class KubectlArgoRollouts < Formula
     desc "Kubectl Argo Rollouts Plugin."
     homepage "https://argoproj.io"
     baseurl = "https://github.com/argoproj/argo-rollouts/releases/download"
-    version "v1.7.1"
+    version "v1.7.2"
 
     if OS.mac?
       kernel = "darwin"
-      sha256 "173f56252e6d08fe564638a0e28360994430e4ca444713bd5ccfe6392d4a02fa"
+      sha256 "cd5c9f39150189c844f7f4b37c149d77e8235edd5d3b48abbf681fc915226d34"
     elsif OS.linux?
       kernel = "linux"
-      sha256 "b42859a4ead2b02dc1a53a101490f60adc9915b602e033ddc49e78e74a20895b"
+      sha256 "af7eac6593bbcac4e219960995e78f6a4b3bb1e6aa47e15a495beb1a4d2da177"
     end
 
     @@bin_name = "kubectl-argo-rollouts-" + kernel + "-amd64"
-    url baseurl + "/v1.7.1/" + @@bin_name
+    url baseurl + "/v1.7.2/" + @@bin_name
 
     def install
       bin.install @@bin_name

--- a/kubectl-argo-rollouts@1.7.rb
+++ b/kubectl-argo-rollouts@1.7.rb
@@ -3,18 +3,18 @@ class KubectlArgoRolloutsAT17 < Formula
     desc "Kubectl Argo Rollouts Plugin."
     homepage "https://argoproj.io"
     baseurl = "https://github.com/argoproj/argo-rollouts/releases/download"
-    version "v1.7.1"
+    version "v1.7.2"
 
     if OS.mac?
       kernel = "darwin"
-      sha256 "173f56252e6d08fe564638a0e28360994430e4ca444713bd5ccfe6392d4a02fa"
+      sha256 "cd5c9f39150189c844f7f4b37c149d77e8235edd5d3b48abbf681fc915226d34"
     elsif OS.linux?
       kernel = "linux"
-      sha256 "b42859a4ead2b02dc1a53a101490f60adc9915b602e033ddc49e78e74a20895b"
+      sha256 "af7eac6593bbcac4e219960995e78f6a4b3bb1e6aa47e15a495beb1a4d2da177"
     end
 
     @@bin_name = "kubectl-argo-rollouts-" + kernel + "-amd64"
-    url baseurl + "/v1.7.1/" + @@bin_name
+    url baseurl + "/v1.7.2/" + @@bin_name
 
     def install
       bin.install @@bin_name


### PR DESCRIPTION
The prior change didn't work since I omitted "v" prefix from the version number.

I'll send a separate PR to fix update.sh to validate this