### PR TITLE
fix update.sh to error on failed curl

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -31,13 +31,13 @@ fi
 # OSX
 OSX_CLI_NAME="${CLI_NAME}-darwin-amd64"
 OSX_BINPATH="/tmp/${OSX_CLI_NAME}"
-curl -L -o ${OSX_BINPATH} -s "${URL_BASE}/${VERSION}/${OSX_CLI_NAME}"
+curl --fail -L -o ${OSX_BINPATH} -s "${URL_BASE}/${VERSION}/${OSX_CLI_NAME}" || (echo "Failed to curl (${URL_BASE}/${VERSION}/${OSX_CLI_NAME})" && exit 1)
 OSX_SHA256=$(shasum -a 256 "${OSX_BINPATH}" | awk '{print $1}')
 
 # Linux
 LINUX_CLI_NAME="${CLI_NAME}-linux-amd64"
 LINUX_BINPATH="/tmp/${LINUX_CLI_NAME}"
-curl -L -o ${LINUX_BINPATH} -s "${URL_BASE}/${VERSION}/${LINUX_CLI_NAME}"
+curl --fail -L -o ${LINUX_BINPATH} -s "${URL_BASE}/${VERSION}/${LINUX_CLI_NAME}" || (echo "Failed to curl (${URL_BASE}/${VERSION}/${LINUX_CLI_NAME})" && exit 1)
 LINUX_SHA256=$(shasum -a 256 "${LINUX_BINPATH}" | awk '{print $1}')
 
 CLASS_POSTFIX=$(echo ${BREW_VERSION} | tr -d '.')


### PR DESCRIPTION
now update.sh will fail with an error message if the curl fails to download the required binary.

previously it would pass and hash the error body which would generate an invalid config.

This led to this PR being merged with an invalid pointer to a file that doesn't exist:
https://github.com/argoproj/homebrew-tap/pull/34

Sample output when running the script with an invalid version:

```
./update.sh kubectl-argo-rollouts 1.7.2
+ [ 2 -lt 2 ]
+ CLI_NAME=kubectl-argo-rollouts
+ VERSION=1.7.2
+ BREW_VERSION=
+ [ kubectl-argo-rollouts = argocd ]
+ [ kubectl-argo-rollouts = argo ]
+ [ kubectl-argo-rollouts = kubectl-argo-rollouts ]
+ URL_BASE=https://github.com/argoproj/argo-rollouts/releases/download
+ CLASSNAME=KubectlArgoRollouts
+ DESC=Kubectl Argo Rollouts Plugin.
+ OSX_CLI_NAME=kubectl-argo-rollouts-darwin-amd64
+ OSX_BINPATH=/tmp/kubectl-argo-rollouts-darwin-amd64
+ curl --fail -L -o /tmp/kubectl-argo-rollouts-darwin-amd64 -s https://github.com/argoproj/argo-rollouts/releases/download/1.7.2/kubectl-argo-rollouts-darwin-amd64
+ echo Failed to curl (https://github.com/argoproj/argo-rollouts/releases/download/1.7.2/kubectl-argo-rollouts-darwin-amd64)
Failed to curl (https://github.com/argoproj/argo-rollouts/releases/download/1.7.2/kubectl-argo-rollouts-darwin-amd64)
+ exit 1
```

Valid version still works:
```
./update.sh kubectl-argo-rollouts v1.7.2
+ [ 2 -lt 2 ]
+ CLI_NAME=kubectl-argo-rollouts
+ VERSION=v1.7.2
+ BREW_VERSION=
+ [ kubectl-argo-rollouts = argocd ]
+ [ kubectl-argo-rollouts = argo ]
+ [ kubectl-argo-rollouts = kubectl-argo-rollouts ]
+ URL_BASE=https://github.com/argoproj/argo-rollouts/releases/download
+ CLASSNAME=KubectlArgoRollouts
+ DESC=Kubectl Argo Rollouts Plugin.
+ OSX_CLI_NAME=kubectl-argo-rollouts-darwin-amd64
+ OSX_BINPATH=/tmp/kubectl-argo-rollouts-darwin-amd64
+ curl --fail -L -o /tmp/kubectl-argo-rollouts-darwin-amd64 -s https://github.com/argoproj/argo-rollouts/releases/download/v1.7.2/kubectl-argo-rollouts-darwin-amd64
+ shasum -a 256 /tmp/kubectl-argo-rollouts-darwin-amd64
+ awk {print $1}
+ OSX_SHA256=cd5c9f39150189c844f7f4b37c149d77e8235edd5d3b48abbf681fc915226d34
+ LINUX_CLI_NAME=kubectl-argo-rollouts-linux-amd64
+ LINUX_BINPATH=/tmp/kubectl-argo-rollouts-linux-amd64
+ curl --fail -L -o /tmp/kubectl-argo-rollouts-linux-amd64 -s https://github.com/argoproj/argo-rollouts/releases/download/v1.7.2/kubectl-argo-rollouts-linux-amd64
+ + awk {print $1}
shasum -a 256 /tmp/kubectl-argo-rollouts-linux-amd64
+ LINUX_SHA256=af7eac6593bbcac4e219960995e78f6a4b3bb1e6aa47e15a495beb1a4d2da177
+ + echo
tr -d .
+ CLASS_POSTFIX=
+ echo
+ sed s/@/AT/g
+ CLASS_POSTFIX=
+ TEMPLATE=# This is an auto-generated file. DO NOT EDIT
class KubectlArgoRollouts < Formula
    desc "Kubectl Argo Rollouts Plugin."
    homepage "https://argoproj.io"
    baseurl = "https://github.com/argoproj/argo-rollouts/releases/download"
    version "v1.7.2"

    if OS.mac?
      kernel = "darwin"
      sha256 "cd5c9f39150189c844f7f4b37c149d77e8235edd5d3b48abbf681fc915226d34"
    elsif OS.linux?
      kernel = "linux"
      sha256 "af7eac6593bbcac4e219960995e78f6a4b3bb1e6aa47e15a495beb1a4d2da177"
    end

    @@bin_name = "kubectl-argo-rollouts-" + kernel + "-amd64"
    url baseurl + "/v1.7.2/" + @@bin_name

    def install
      bin.install @@bin_name
      mv bin/ + @@bin_name.to_s, bin/"kubectl-argo-rollouts"
    end
end
+ echo # This is an auto-generated file. DO NOT EDIT
class KubectlArgoRollouts < Formula
    desc "Kubectl Argo Rollouts Plugin."
    homepage "https://argoproj.io"
    baseurl = "https://github.com/argoproj/argo-rollouts/releases/download"
    version "v1.7.2"

    if OS.mac?
      kernel = "darwin"
      sha256 "cd5c9f39150189c844f7f4b37c149d77e8235edd5d3b48abbf681fc915226d34"
    elsif OS.linux?
      kernel = "linux"
      sha256 "af7eac6593bbcac4e219960995e78f6a4b3bb1e6aa47e15a495beb1a4d2da177"
    end

    @@bin_name = "kubectl-argo-rollouts-" + kernel + "-amd64"
    url baseurl + "/v1.7.2/" + @@bin_name

    def install
      bin.install @@bin_name
      mv bin/ + @@bin_name.to_s, bin/"kubectl-argo-rollouts"
    end
end
```